### PR TITLE
Remove deprecated CrafterCMSNext references

### DIFF
--- a/authoring/static-assets/plugins/org/craftercms/plugin/bulkedit/sidebar/bulkedit/index.js
+++ b/authoring/static-assets/plugins/org/craftercms/plugin/bulkedit/sidebar/bulkedit/index.js
@@ -3,7 +3,7 @@ var React = craftercms.libs.React && Object.prototype.hasOwnProperty.call(crafte
 var { FormControl: FormControl$1, InputLabel: InputLabel$1, Select: Select$1, MenuItem: MenuItem$2, styled: styled$5, TextField: TextField$1, Button: Button$1, Dialog, DialogTitle, DialogContent, Box: Box$2, DialogActions, Paper: Paper$1, Accordion, AccordionSummary, Typography: Typography$2, AccordionDetails, FormLabel: FormLabel$2, RadioGroup, FormControlLabel: FormControlLabel$2, Radio, Tooltip: Tooltip$1, IconButton: IconButton$1, Drawer, List: List$2, ListItem, Divider: Divider$2, ListItemButton, ListItemIcon: ListItemIcon$2, ListItemText: ListItemText$2, CssBaseline: CssBaseline$1, Toolbar: Toolbar$2, Stack } = craftercms.libs.MaterialUI;
 var { createSvgIcon: createSvgIcon$2 } = craftercms.libs.MaterialUI;
 var _utils = craftercms.libs.MaterialUI && Object.prototype.hasOwnProperty.call(craftercms.libs.MaterialUI, 'default') ? craftercms.libs.MaterialUI['default'] : craftercms.libs.MaterialUI;
-var { Subject } = CrafterCMSNext.rxjs;
+var { Subject } = craftercms.libs.rxjs;
 var ReactDOM = craftercms.libs.ReactDOM && Object.prototype.hasOwnProperty.call(craftercms.libs.ReactDOM, 'default') ? craftercms.libs.ReactDOM['default'] : craftercms.libs.ReactDOM;
 
 function getDefaultExportFromCjs (x) {
@@ -804,14 +804,14 @@ var CookieHelper = {
 var HttpHelper = {
   get: function get(url) {
     return new Promise(function (resolve, reject) {
-      CrafterCMSNext.util.ajax.get(url).subscribe(function (response) {
+      craftercms.utils.ajax.get(url).subscribe(function (response) {
         resolve(response);
       });
     });
   },
   post: function post(url, body, headers) {
     return new Promise(function (resolve, reject) {
-      CrafterCMSNext.util.ajax.post(url, body, headers).subscribe(function (response) {
+      craftercms.utils.ajax.post(url, body, headers).subscribe(function (response) {
         resolve(response);
       });
     });
@@ -43938,7 +43938,7 @@ var ContentTypeHelper = {
 var DialogHelper = {
   showEditDialog: function showEditDialog(payload, success, failed) {
     var eventId = 'bulkEditDialogCallback';
-    CrafterCMSNext.system.store.dispatch({
+    craftercms.getStore().dispatch({
       type: 'SHOW_EDIT_DIALOG',
       payload: Object.assign(payload, {
         onSaveSuccess: {
@@ -43969,7 +43969,7 @@ var DialogHelper = {
         }
       })
     });
-    CrafterCMSNext.createLegacyCallbackListener(eventId, function (response) {
+    craftercms.utils.dom.createCustomDocumentEventListener(eventId, function (response) {
       if (response.type === 'EMBEDDED_LEGACY_FORM_SUCCESS' || response.type === 'success') {
         success(response);
       } else {
@@ -44789,7 +44789,7 @@ var DataSheet = /*#__PURE__*/React.forwardRef(function (props, ref) {
         field = selectedRow.field;
     var payload = {
       path: row.path,
-      authoringBase: CrafterCMSNext.system.store.getState().env.authoringBase,
+      authoringBase: craftercms.getStore().getState().env.authoringBase,
       site: StudioAPI.siteId(),
       readonly: !isEdit,
       selectedFields: [field]
@@ -44899,7 +44899,7 @@ var DataSheet = /*#__PURE__*/React.forwardRef(function (props, ref) {
               row = selectedRow.row;
               payload = {
                 path: row.path,
-                authoringBase: CrafterCMSNext.system.store.getState().env.authoringBase,
+                authoringBase: craftercms.getStore().getState().env.authoringBase,
                 site: StudioAPI.siteId(),
                 readonly: false
               };

--- a/authoring/ui-sources/rollup.config.js
+++ b/authoring/ui-sources/rollup.config.js
@@ -20,7 +20,7 @@ const globals = {
   '@mui/material': 'craftercms.libs.MaterialUI',
   '@craftercms/studio-ui': 'craftercms.libs.StudioUI',
   '@mui/material/utils': 'craftercms.libs.MaterialUI',
-  'rxjs': 'CrafterCMSNext.rxjs',
+  'rxjs': 'craftercms.libs.rxjs',
 }
 
 function cleanName(name) {

--- a/authoring/ui-sources/src/components/DataSheet.js
+++ b/authoring/ui-sources/src/components/DataSheet.js
@@ -519,7 +519,7 @@ const DataSheet = React.forwardRef((props, ref) => {
     const { row, field } = selectedRow;
     const payload = {
       path: row.path,
-      authoringBase: CrafterCMSNext.system.store.getState().env.authoringBase,
+      authoringBase: craftercms.getStore().getState().env.authoringBase,
       site: StudioAPI.siteId(),
       readonly: !isEdit,
       selectedFields: [field]
@@ -571,7 +571,7 @@ const DataSheet = React.forwardRef((props, ref) => {
     const { row } = selectedRow;
     const payload = {
       path: row.path,
-      authoringBase: CrafterCMSNext.system.store.getState().env.authoringBase,
+      authoringBase: craftercms.getStore().getState().env.authoringBase,
       site: StudioAPI.siteId(),
       readonly: false,
     };

--- a/authoring/ui-sources/src/helpers/dialog.js
+++ b/authoring/ui-sources/src/helpers/dialog.js
@@ -17,7 +17,7 @@
 const DialogHelper = {
   showEditDialog: (payload, success, failed) => {
     const eventId = 'bulkEditDialogCallback';
-    CrafterCMSNext.system.store.dispatch({
+    craftercms.getStore().dispatch({
       type: 'SHOW_EDIT_DIALOG',
       payload: Object.assign(payload, {
         onSaveSuccess: {
@@ -47,7 +47,7 @@ const DialogHelper = {
         }
       })
     });
-    CrafterCMSNext.createLegacyCallbackListener(eventId, (response) => {
+    craftercms.utils.dom.createCustomDocumentEventListener(eventId, (response) => {
       if (response.type === 'EMBEDDED_LEGACY_FORM_SUCCESS' || response.type === 'success') {
         success(response);
       } else {

--- a/authoring/ui-sources/src/helpers/http.js
+++ b/authoring/ui-sources/src/helpers/http.js
@@ -17,14 +17,14 @@
 const HttpHelper = {
   get(url) {
     return new Promise((resolve, reject) => {
-      CrafterCMSNext.util.ajax.get(url).subscribe((response) => {
+      craftercms.utils.ajax.get(url).subscribe((response) => {
         resolve(response);
       });
     });
   },
   post(url, body, headers) {
     return new Promise((resolve, reject) => {
-      CrafterCMSNext.util.ajax.post(url, body, headers).subscribe((response) => {
+      craftercms.utils.ajax.post(url, body, headers).subscribe((response) => {
         resolve(response);
       });
     });

--- a/craftercms-plugin.yaml
+++ b/craftercms-plugin.yaml
@@ -40,53 +40,26 @@ plugin:
     url: https://opensource.org/licenses/MIT
   crafterCmsVersions:
     - major: 4
-      minor: 0
+      minor: 1
       patch: 0
     - major: 4
-      minor: 0
+      minor: 1
       patch: 1
     - major: 4
-      minor: 0
+      minor: 1
       patch: 2
     - major: 4
-      minor: 0
+      minor: 1
       patch: 3
     - major: 4
-      minor: 0
+      minor: 1
       patch: 4
     - major: 4
-      minor: 0
+      minor: 1
       patch: 5
     - major: 4
-      minor: 0
+      minor: 1
       patch: 6
-    - major: 4
-      minor: 0
-      patch: 7
-    - major: 4
-      minor: 0
-      patch: 8
-    - major: 4
-      minor: 0
-      patch: 9
-    - major: 4
-      minor: 0
-      patch: 10
-    - major: 4
-      minor: 1
-      patch: 0
-    - major: 4
-      minor: 1
-      patch: 1
-    - major: 4
-      minor: 1
-      patch: 2
-    - major: 4
-      minor: 1
-      patch: 3
-    - major: 4
-      minor: 1
-      patch: 4
     - major: 4
       minor: 2
       patch: 0

--- a/craftercms-plugin.yaml
+++ b/craftercms-plugin.yaml
@@ -16,7 +16,7 @@ plugin:
   version:
     major: 1
     minor: 0
-    patch: 13
+    patch: 14
   description: Provide bulk editing capability to Crafter Studio
   documentation: "https://raw.githubusercontent.com/craftercms/bulkedit-plugin/master/README.md"
   website:


### PR DESCRIPTION
This updates the plugin to use `craftercms` references which is the replacement for `CrafterCMSNext` in 4.2.0
@russdanner FYI
